### PR TITLE
Update about and contact sections

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="3211d56d-589f-4ed4-a74f-5c777b49cf43" name="Changes" comment="wip">
+    <list default="true" id="a9c60c8d-c0c4-4cd6-af35-405cf4913305" name="Changes" comment="wip">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/galerie.html" beforeDir="false" afterPath="$PROJECT_DIR$/galerie.html" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/sluzby.html" beforeDir="false" afterPath="$PROJECT_DIR$/sluzby.html" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -22,12 +21,6 @@
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
-  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
-  "lastFilter": {
-    "state": "OPEN",
-    "assignee": "siopaulo"
-  }
-}]]></component>
   <component name="GitToolBoxStore">
     <option name="recentBranches">
       <RecentBranches>
@@ -37,16 +30,12 @@
               <option name="branches">
                 <list>
                   <RecentBranch>
-                    <option name="branchName" value="codex/upravit-index-a-stránky-podle-požadavků" />
-                    <option name="lastUsedInstant" value="1750903893" />
+                    <option name="branchName" value="codex/update-homepage-and-services-page" />
+                    <option name="lastUsedInstant" value="1750906943" />
                   </RecentBranch>
                   <RecentBranch>
                     <option name="branchName" value="master" />
-                    <option name="lastUsedInstant" value="1750899827" />
-                  </RecentBranch>
-                  <RecentBranch>
-                    <option name="branchName" value="codex/vytvořit-moderní-statické-stránky-s-tailwind" />
-                    <option name="lastUsedInstant" value="1750898374" />
+                    <option name="lastUsedInstant" value="1750906942" />
                   </RecentBranch>
                 </list>
               </option>
@@ -57,71 +46,15 @@
       </RecentBranches>
     </option>
   </component>
-  <component name="GithubPullRequestsUISettings"><![CDATA[{
-  "selectedUrlAndAccountId": {
-    "url": "https://github.com/siopaulo/chejnovskaStavby.git",
-    "accountId": "77828aef-9ba1-4e3d-8eaa-3f629ba7fcda"
-  }
-}]]></component>
-  <component name="ProjectColorInfo"><![CDATA[{
-  "associatedIndex": 7
-}]]></component>
-  <component name="ProjectId" id="2z1PbEnnkJUlqilFki6N08POsPV" />
-  <component name="ProjectViewState">
-    <option name="hideEmptyMiddlePackages" value="true" />
-    <option name="showLibraryContents" value="true" />
-  </component>
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
-    "JavaScript Debug.galerie.html.executor": "Run",
     "JavaScript Debug.index.html.executor": "Run",
-    "JavaScript Debug.sluzby.html.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "git-widget-placeholder": "codex/upravit-index-a-stránky-podle-požadavků",
-    "last_opened_file_path": "//wsl.localhost/Ubuntu/home/pauli/ChejnovskyBarak/img",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "vue.rearranger.settings.migration": "true"
+    "git-widget-placeholder": "#5 on codex/update-homepage-and-services-page",
+    "node.js.selected.package.tslint": "(autodetect)"
   }
 }]]></component>
-  <component name="RecentsManager">
-    <key name="CopyFile.RECENT_KEYS">
-      <recent name="\\wsl.localhost\Ubuntu\home\pauli\ChejnovskyBarak\img" />
-    </key>
-  </component>
-  <component name="SharedIndexes">
-    <attachedChunks>
-      <set>
-        <option value="bundled-js-predefined-d6986cc7102b-76f8388c3a79-JavaScript-WS-243.24978.60" />
-      </set>
-    </attachedChunks>
-  </component>
-  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
-    <task active="true" id="Default" summary="Default task">
-      <changelist id="3211d56d-589f-4ed4-a74f-5c777b49cf43" name="Changes" comment="" />
-      <created>1750895675838</created>
-      <option name="number" value="Default" />
-      <option name="presentableId" value="Default" />
-      <updated>1750895675838</updated>
-      <workItem from="1750895678048" duration="9174000" />
-    </task>
-    <task id="LOCAL-00001" summary="wip">
-      <option name="closed" value="true" />
-      <created>1750903418760</created>
-      <option name="number" value="00001" />
-      <option name="presentableId" value="LOCAL-00001" />
-      <option name="project" value="LOCAL" />
-      <updated>1750903418760</updated>
-    </task>
-    <option name="localTasksCounter" value="2" />
     <servers />
-  </component>
-  <component name="TypeScriptGeneratedFilesManager">
-    <option name="version" value="3" />
   </component>
   <component name="VcsManagerConfiguration">
     <MESSAGE value="wip" />

--- a/galerie.html
+++ b/galerie.html
@@ -456,16 +456,21 @@
                 <h3 class="text-2xl font-bold text-white mb-4">FASAPOLYCZ s.r.o.</h3>
                 <p class="mb-4">Profesionální fasády, omítky a zateplení. Kvalita a spolehlivost již více než 15 let.</p>
                 <div class="flex space-x-4">
-                    <div class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors cursor-pointer">
+                    <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="YouTube">
                         <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.63 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/>
+                            <path d="M10 15l5-3-5-3v6zm9-6.5a2.5 2.5 0 00-1.77-2.4C15.6 5.5 12 5.5 12 5.5s-3.6 0-5.23.6A2.5 2.5 0 005 8.5v7a2.5 2.5 0 001.77 2.4c1.63.6 5.23.6 5.23.6s3.6 0 5.23-.6A2.5 2.5 0 0019 15.5v-7z"/>
                         </svg>
-                    </div>
-                    <div class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors cursor-pointer">
+                    </a>
+                    <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="Instagram">
                         <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M22.46 6c-.77.35-1.6.58-2.46.69.88-.53 1.56-1.37 1.88-2.38-.83.5-1.75.85-2.72 1.05C18.37 4.5 17.26 4 16 4c-2.35 0-4.27 1.92-4.27 4.29 0 .34.04.67.11.98C8.28 9.09 5.11 7.38 3 4.79c-.37.63-.58 1.37-.58 2.15 0 1.49.75 2.81 1.91 3.56-.71 0-1.37-.2-1.95-.5v.03c0 2.08 1.48 3.82 3.44 4.21a4.22 4.22 0 0 1-1.93.07 4.28 4.28 0 0 0 4 2.98 8.521 8.521 0 0 1-5.33 1.84c-.34 0-.68-.02-1.02-.06C3.44 20.29 5.7 21 8.12 21 16 21 20.33 14.46 20.33 8.79c0-.19 0-.37-.01-.56.84-.6 1.56-1.36 2.14-2.23z"/>
+                            <path d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm10 2c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3h10zM12 8a4 4 0 100 8 4 4 0 000-8zm5-3a1 1 0 100 2 1 1 0 000-2z"/>
                         </svg>
-                    </div>
+                    </a>
+                    <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="Facebook">
+                        <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                            <path d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.988H7.898v-2.89h2.54V9.797c0-2.507 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.47h-1.26c-1.243 0-1.63.771-1.63 1.562v1.873h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"/>
+                        </svg>
+                    </a>
                 </div>
             </div>
             <div>

--- a/index.html
+++ b/index.html
@@ -144,8 +144,8 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
                             </svg>
                         </div>
-                        <h3 class="font-bold text-xl text-gray-800 mb-4">Kontaktujte nás</h3>
-                        <a href="kontakt.html" class="inline-block bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">Přejít na stránku Kontakt</a>
+                        <h3 class="font-bold text-xl text-gray-800 mb-4">Zjistěte více o našich službách</h3>
+                        <a href="sluzby.html" class="inline-block bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">Přejít na stránku Služby</a>
                     </div>
                 </div>
             </div>
@@ -169,11 +169,13 @@
         <div class="max-w-6xl mx-auto px-4">
             <div class="text-center mb-12">
                 <h2 class="text-4xl font-bold text-gradient mb-4">O nás</h2>
-                <p class="text-xl text-gray-600">Naše firma vznikla v roce 2013 na základě dlouholetých zkušeností z Německa.</p>
+                <p class="text-xl text-gray-600">FASAPOLYCZ s.r.o. působí od roku 2013 a navazuje na mnohaleté zkušenosti z Německa.</p>
             </div>
-            <p class="text-gray-700 max-w-3xl mx-auto leading-relaxed text-center">
-                Díky kvalifikovanému týmu dokážeme realizovat projekty přesně podle představ zákazníků. Mezi naše spokojené partnery patří HPP Putz GmbH, Trinkerl Putz GmbH a mnoho soukromých investorů.
-            </p>
+            <ul class="list-disc list-inside space-y-3 text-gray-700 max-w-3xl mx-auto">
+                <li>Realizujeme kompletní vnitřní i vnější omítky a zateplení domů.</li>
+                <li>Spolupracujeme s partnery jako HPP Putz GmbH nebo Trinkerl Putz GmbH.</li>
+                <li>Dbáme na kvalitu provedení, čistotu prací a spokojenost zákazníka.</li>
+            </ul>
         </div>
     </section>
 
@@ -183,9 +185,10 @@
             <div class="text-center mb-16">
                 <h2 class="text-4xl font-bold text-gradient mb-4">Ukázka realizací</h2>
                 <p class="text-xl text-gray-600 mb-6">Podívejte se na naše nejnovější projekty</p>
-                <p class="text-gray-600">
-                    Další fotografie najdete v <a href="galerie.html" class="text-blue-700 underline hover:text-blue-800 font-semibold">galerii</a>.
+                <p class="text-gray-600 mb-4">
+                    Další fotografie najdete v naší galerii.
                 </p>
+                <a href="galerie.html" class="inline-block bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">Přejít do galerie</a>
             </div>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
                 <div class="group relative overflow-hidden rounded-2xl shadow-lg">
@@ -298,16 +301,21 @@
                 <h3 class="text-2xl font-bold text-white mb-4">FASAPOLYCZ s.r.o.</h3>
                 <p class="mb-4">Profesionální fasády, omítky a zateplení. Kvalita a spolehlivost již více než 15 let.</p>
                 <div class="flex space-x-4">
-                    <div class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors cursor-pointer">
+                    <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="YouTube">
                         <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/>
+                            <path d="M10 15l5-3-5-3v6zm9-6.5a2.5 2.5 0 00-1.77-2.4C15.6 5.5 12 5.5 12 5.5s-3.6 0-5.23.6A2.5 2.5 0 005 8.5v7a2.5 2.5 0 001.77 2.4c1.63.6 5.23.6 5.23.6s3.6 0 5.23-.6A2.5 2.5 0 0019 15.5v-7z"/>
                         </svg>
-                    </div>
-                    <div class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors cursor-pointer">
+                    </a>
+                    <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="Instagram">
                         <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M22.46 6c-.77.35-1.6.58-2.46.69.88-.53 1.56-1.37 1.88-2.38-.83.5-1.75.85-2.72 1.05C18.37 4.5 17.26 4 16 4c-2.35 0-4.27 1.92-4.27 4.29 0 .34.04.67.11.98C8.28 9.09 5.11 7.38 3 4.79c-.37.63-.58 1.37-.58 2.15 0 1.49.75 2.81 1.91 3.56-.71 0-1.37-.2-1.95-.5v.03c0 2.08 1.48 3.82 3.44 4.21a4.22 4.22 0 0 1-1.93.07 4.28 4.28 0 0 0 4 2.98 8.521 8.521 0 0 1-5.33 1.84c-.34 0-.68-.02-1.02-.06C3.44 20.29 5.7 21 8.12 21 16 21 20.33 14.46 20.33 8.79c0-.19 0-.37-.01-.56.84-.6 1.56-1.36 2.14-2.23z"/>
+                            <path d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm10 2c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3h10zM12 8a4 4 0 100 8 4 4 0 000-8zm5-3a1 1 0 100 2 1 1 0 000-2z"/>
                         </svg>
-                    </div>
+                    </a>
+                    <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="Facebook">
+                        <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                            <path d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.988H7.898v-2.89h2.54V9.797c0-2.507 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.47h-1.26c-1.243 0-1.63.771-1.63 1.562v1.873h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"/>
+                        </svg>
+                    </a>
                 </div>
             </div>
             <div>

--- a/index.html
+++ b/index.html
@@ -164,73 +164,16 @@
         </div>
     </section>
 
-    <!-- Služby detail -->
+    <!-- O nás -->
     <section class="py-20 bg-gradient-to-br from-gray-50 to-blue-50">
         <div class="max-w-6xl mx-auto px-4">
-            <div class="text-center mb-16">
-                <h2 class="text-4xl font-bold text-gradient mb-4">Naše služby</h2>
-                <p class="text-xl text-gray-600">Kompletní spektrum stavebních služeb pro váš domov</p>
+            <div class="text-center mb-12">
+                <h2 class="text-4xl font-bold text-gradient mb-4">O nás</h2>
+                <p class="text-xl text-gray-600">Naše firma vznikla v roce 2013 na základě dlouholetých zkušeností z Německa.</p>
             </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-                <div class="service-card bg-white rounded-2xl p-8 shadow-lg">
-                    <img src="img/c6e6473b-52e3-46c8-a5f7-585113593157.jpeg" alt="Vnitřní omítky" class="w-full h-40 object-cover rounded-lg mb-4">
-                    <div class="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-700 rounded-2xl mb-6 flex items-center justify-center">
-                        <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
-                        </svg>
-                    </div>
-                    <h3 class="text-2xl font-bold text-gray-800 mb-4">Vnitřní omítky</h3>
-                    <p class="text-gray-600 mb-4">Strojní omítky stěn a stropů na klíč, jednovrstvé, dvouvrstvé, hladké i filcované. Kompletní dodávka včetně úklidu.</p>
-                    <ul class="text-sm text-gray-600 space-y-1">
-                        <li>• Jednovrstvé a dvouvrstvé omítky</li>
-                        <li>• Hladké i strukturované povrchy</li>
-                        <li>• Kompletní úklid po práci</li>
-                    </ul>
-                </div>
-                <div class="service-card bg-white rounded-2xl p-8 shadow-lg">
-                    <img src="img/Fasada Blovice 2.jpg" alt="Vnější omítky" class="w-full h-40 object-cover rounded-lg mb-4">
-                    <div class="w-16 h-16 bg-gradient-to-br from-green-500 to-green-700 rounded-2xl mb-6 flex items-center justify-center">
-                        <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2v0"></path>
-                        </svg>
-                    </div>
-                    <h3 class="text-2xl font-bold text-gray-800 mb-4">Vnější omítky a zateplení</h3>
-                    <p class="text-gray-600 mb-4">Strojní i šlechtěné omítky, včetně probarvení nebo finálního nátěru. Realizujeme i kompletní zateplení domů.</p>
-                    <ul class="text-sm text-gray-600 space-y-1">
-                        <li>• Zateplení včetně materiálu</li>
-                        <li>• Dekorativní a strukturální omítky</li>
-                        <li>• Barevné řešení fasád</li>
-                    </ul>
-                </div>
-                <div class="service-card bg-white rounded-2xl p-8 shadow-lg">
-                    <div class="w-16 h-16 bg-gradient-to-br from-orange-500 to-orange-700 rounded-2xl mb-6 flex items-center justify-center">
-                        <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"></path>
-                        </svg>
-                    </div>
-                    <h3 class="text-2xl font-bold text-gray-800 mb-4">Sanační práce</h3>
-                    <p class="text-gray-600 mb-4">Sanační omítky pro historické a starší objekty s problémy s vlhkostí.</p>
-                    <ul class="text-sm text-gray-600 space-y-1">
-                        <li>• Řešení problémů s vlhkostí</li>
-                        <li>• Historické objekty</li>
-                        <li>• Speciální sanační materiály</li>
-                    </ul>
-                </div>
-                <div class="service-card bg-white rounded-2xl p-8 shadow-lg">
-                    <div class="w-16 h-16 bg-gradient-to-br from-purple-500 to-purple-700 rounded-2xl mb-6 flex items-center justify-center">
-                        <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path>
-                        </svg>
-                    </div>
-                    <h3 class="text-2xl font-bold text-gray-800 mb-4">Půjčovna lešení</h3>
-                    <p class="text-gray-600 mb-4">Montáž, demontáž, doprava a pronájem rámového lešení pro vaše stavební projekty.</p>
-                    <ul class="text-sm text-gray-600 space-y-1">
-                        <li>• Rámové lešení</li>
-                        <li>• Montáž a demontáž</li>
-                        <li>• Doprava v ceně</li>
-                    </ul>
-                </div>
-            </div>
+            <p class="text-gray-700 max-w-3xl mx-auto leading-relaxed text-center">
+                Díky kvalifikovanému týmu dokážeme realizovat projekty přesně podle představ zákazníků. Mezi naše spokojené partnery patří HPP Putz GmbH, Trinkerl Putz GmbH a mnoho soukromých investorů.
+            </p>
         </div>
     </section>
 

--- a/kontakt.html
+++ b/kontakt.html
@@ -80,16 +80,21 @@
                     <h3 class="text-2xl font-bold text-white mb-4">FASAPOLYCZ s.r.o.</h3>
                     <p class="mb-4">Profesionální fasády, omítky a zateplení. Kvalita a spolehlivost již více než 15 let.</p>
                     <div class="flex space-x-4">
-                        <div class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors cursor-pointer">
+                        <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="YouTube">
                             <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                                <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.63 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/>
+                                <path d="M10 15l5-3-5-3v6zm9-6.5a2.5 2.5 0 00-1.77-2.4C15.6 5.5 12 5.5 12 5.5s-3.6 0-5.23.6A2.5 2.5 0 005 8.5v7a2.5 2.5 0 001.77 2.4c1.63.6 5.23.6 5.23.6s3.6 0 5.23-.6A2.5 2.5 0 0019 15.5v-7z"/>
                             </svg>
-                        </div>
-                        <div class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors cursor-pointer">
+                        </a>
+                        <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="Instagram">
                             <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                                <path d="M22.46 6c-.77.35-1.6.58-2.46.69.88-.53 1.56-1.37 1.88-2.38-.83.5-1.75.85-2.72 1.05C18.37 4.5 17.26 4 16 4c-2.35 0-4.27 1.92-4.27 4.29 0 .34.04.67.11.98C8.28 9.09 5.11 7.38 3 4.79c-.37.63-.58 1.37-.58 2.15 0 1.49.75 2.81 1.91 3.56-.71 0-1.37-.2-1.95-.5v.03c0 2.08 1.48 3.82 3.44 4.21a4.22 4.22 0 0 1-1.93.07 4.28 4.28 0 0 0 4 2.98 8.521 8.521 0 0 1-5.33 1.84c-.34 0-.68-.02-1.02-.06C3.44 20.29 5.7 21 8.12 21 16 21 20.33 14.46 20.33 8.79c0-.19 0-.37-.01-.56.84-.6 1.56-1.36 2.14-2.23z"/>
+                                <path d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm10 2c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3h10zM12 8a4 4 0 100 8 4 4 0 000-8zm5-3a1 1 0 100 2 1 1 0 000-2z"/>
                             </svg>
-                        </div>
+                        </a>
+                        <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="Facebook">
+                            <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.988H7.898v-2.89h2.54V9.797c0-2.507 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.47h-1.26c-1.243 0-1.63.771-1.63 1.562v1.873h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"/>
+                            </svg>
+                        </a>
                     </div>
                 </div>
                 <div>

--- a/sluzby.html
+++ b/sluzby.html
@@ -2,6 +2,16 @@
 <html lang="cs">
 <head>
     <meta charset="UTF-8">
+    <title>Služby - FASAPOLYCZ s.r.o.</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.css" />
+    <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .hero-overlay { background: linear-gradient(135deg, rgba(30,58,138,0.85) 0%, rgba(59,130,246,0.75) 100%); }
+        .service-card {
             background: linear-gradient(145deg, #ffffff 0%, #f8fafc 100%);
             border: 1px solid rgba(59, 130, 246, 0.1);
             transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);

--- a/sluzby.html
+++ b/sluzby.html
@@ -2,16 +2,6 @@
 <html lang="cs">
 <head>
     <meta charset="UTF-8">
-    <title>Služby - FASAPOLYCZ s.r.o.</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.css" />
-    <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-        .hero-overlay { background: linear-gradient(135deg, rgba(30,58,138,0.85) 0%, rgba(59,130,246,0.75) 100%); }
-        .service-card {
             background: linear-gradient(145deg, #ffffff 0%, #f8fafc 100%);
             border: 1px solid rgba(59, 130, 246, 0.1);
             transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
@@ -53,20 +43,12 @@
             background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);
         }
         .process-step {
-            background: linear-gradient(145deg, #ffffff 0%, #f8fafc 100%);
-            border: 2px solid transparent;
-            background-clip: padding-box;
-            position: relative;
+            background: linear-gradient(135deg, #1e3a8a 0%, #3b82f6 100%);
+            color: #fff;
+            box-shadow: 0 10px 25px rgba(0,0,0,0.1);
         }
         .process-step::before {
-            content: '';
-            position: absolute;
-            inset: 0;
-            padding: 2px;
-            background: linear-gradient(135deg, #3b82f6, #1d4ed8);
-            border-radius: inherit;
-            mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-            mask-composite: exclude;
+            content: none;
         }
         .contact-card {
             background: linear-gradient(145deg,#fff,#f8fafc);
@@ -317,24 +299,24 @@
                     <div class="w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mx-auto mb-6">
                         <span class="text-white text-2xl font-bold">1</span>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-4">Konzultace a návrh</h3>
-                    <p class="text-gray-600">Provedeme detailní obhlídku, prodiskutujeme vaše požadavky a připravíme návrh řešení včetně cenové kalkulace.</p>
+                    <h3 class="text-xl font-bold text-white mb-4">Konzultace a návrh</h3>
+                    <p class="text-blue-100">Provedeme detailní obhlídku, prodiskutujeme vaše požadavky a připravíme návrh řešení včetně cenové kalkulace.</p>
                 </div>
 
                 <div class="process-step rounded-2xl p-8 text-center" data-aos="fade-up" data-aos-delay="100">
                     <div class="w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mx-auto mb-6">
                         <span class="text-white text-2xl font-bold">2</span>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-4">Příprava a dodávka</h3>
-                    <p class="text-gray-600">Zajistíme všechny potřebné materiály, lešení a připravíme pracoviště. Vše organizujeme tak, aby byla minimální zátěž pro zákazníka.</p>
+                    <h3 class="text-xl font-bold text-white mb-4">Příprava a dodávka</h3>
+                    <p class="text-blue-100">Zajistíme všechny potřebné materiály, lešení a připravíme pracoviště. Vše organizujeme tak, aby byla minimální zátěž pro zákazníka.</p>
                 </div>
 
                 <div class="process-step rounded-2xl p-8 text-center" data-aos="fade-up" data-aos-delay="200">
                     <div class="w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mx-auto mb-6">
                         <span class="text-white text-2xl font-bold">3</span>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-4">Realizace a úklid</h3>
-                    <p class="text-gray-600">Provedeme práce dle dohodnutého harmonogramu s průběžnou kontrolou kvality a po dokončení zajistíme kompletní úklid.</p>
+                    <h3 class="text-xl font-bold text-white mb-4">Realizace a úklid</h3>
+                    <p class="text-blue-100">Provedeme práce dle dohodnutého harmonogramu s průběžnou kontrolou kvality a po dokončení zajistíme kompletní úklid.</p>
                 </div>
             </div>
         </div>
@@ -367,15 +349,21 @@
                 <h3 class="text-2xl font-bold text-white mb-4">FASAPOLYCZ s.r.o.</h3>
                 <p class="mb-4">Profesionální fasády, omítky a zateplení. Kvalita a spolehlivost již více než 15 let.</p>
                 <div class="flex space-x-4">
-                    <div class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors cursor-pointer">
+                    <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="YouTube">
                         <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.63 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/>
+                            <path d="M10 15l5-3-5-3v6zm9-6.5a2.5 2.5 0 00-1.77-2.4C15.6 5.5 12 5.5 12 5.5s-3.6 0-5.23.6A2.5 2.5 0 005 8.5v7a2.5 2.5 0 001.77 2.4c1.63.6 5.23.6 5.23.6s3.6 0 5.23-.6A2.5 2.5 0 0019 15.5v-7z"/>
                         </svg>
-                    </div>
-                    <div class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors cursor-pointer">
+                    </a>
+                    <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="Instagram">
                         <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M22.46 6c-.77.35-1.6.58-2.46.69.88-.53 1.56-1.37 1.88-2.38-.83.5-1.75.85-2.72 1.05C18.37 4.5 17.26 4 16 4c-2.35 0-4.27 1.92-4.27 4.29 0 .34.04.67.11.98C8.28 9.09 5.11 7.38 3 4.79c-.37.63-.58 1.37-.58 2.15 0 1.49.75 2.81 1.91 3.56-.71 0-1.37-.2-1.95-.5v.03c0 2.08 1.48 3.82 3.44 4.21a4.22 4.22 0 0 1-1.93.07 4.28 4.28 0 0 0 4 2.98 8.521 8.521 0 0 1-5.33 1.84c-.34 0-.68-.02-1.02-.06C3.44 20.29 5.7 21 8.12 21 16 21 20.33 14.46 20.33 8.79c0-.19 0-.37-.01-.56.84-.6 1.56-1.36 2.14-2.23z"/>
+                            <path d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm10 2c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3h10zM12 8a4 4 0 100 8 4 4 0 000-8zm5-3a1 1 0 100 2 1 1 0 000-2z"/>
                         </svg>
+                    </a>
+                    <a href="#" class="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors" aria-label="Facebook">
+                        <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
+                            <path d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.988H7.898v-2.89h2.54V9.797c0-2.507 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.47h-1.26c-1.243 0-1.63.771-1.63 1.562v1.873h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"/>
+                        </svg>
+                    </a>
                     </div>
                 </div>
             </div>

--- a/sluzby.html
+++ b/sluzby.html
@@ -68,6 +68,10 @@
             mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
             mask-composite: exclude;
         }
+        .contact-card {
+            background: linear-gradient(145deg,#fff,#f8fafc);
+            box-shadow: 0 10px 30px rgba(0,0,0,0.10);
+        }
     </style>
 </head>
 <body class="bg-gray-50 font-sans min-h-screen flex flex-col">
@@ -341,13 +345,16 @@
         <div class="max-w-4xl mx-auto px-4 text-center" data-aos="fade-up">
             <h2 class="text-3xl md:text-4xl font-bold text-white mb-6">Máte projekt? Kontaktujte nás!</h2>
             <p class="text-xl text-white/90 mb-8 max-w-2xl mx-auto">Rádi vám připravíme nezávaznou nabídku a poradíme s výběrem nejvhodnějšího řešení pro váš domov.</p>
-            <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                <a href="tel:+420775976677" class="bg-white text-blue-600 font-semibold px-8 py-4 rounded-xl hover:bg-gray-100 transition-colors inline-flex items-center justify-center">
-                    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
-                    </svg>
-                    Zavolat: +420 775 976 677
-                </a>
+            <div class="flex justify-center">
+                <div class="contact-card rounded-2xl p-8 text-center">
+                    <div class="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-700 rounded-full mx-auto mb-4 flex items-center justify-center">
+                        <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"></path>
+                        </svg>
+                    </div>
+                    <h3 class="font-bold text-xl text-gray-800 mb-4">Kontaktujte nás</h3>
+                    <a href="kontakt.html" class="inline-block bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">Přejít na stránku Kontakt</a>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- replace service overview on homepage with an about section
- add contact card style to the services page and show the same contact card used on the homepage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685cb73ccfec8326a90f563bed1319fd